### PR TITLE
fix: マッチグループ取得APIのパラメータのuserIdを変更

### DIFF
--- a/benchmarker/src/loadTest.ts
+++ b/benchmarker/src/loadTest.ts
@@ -199,7 +199,7 @@ export const createMatchGroupsAPI = () => {
 
 export const getMatchGroupsAPI = () => {
   const res = http.get(
-    url(`/api/v1/match-groups/members/test-user-id?status=open`),
+    url(`/api/v1/match-groups/members/692ee607-9cdf-439b-8b06-1a435c99aa5a?status=open`),
     {
       cookies: {
         SESSION_ID: "test-session-id",


### PR DESCRIPTION
- マッチグループ作成APIの作成者とマッチグループ取得APIの対象ユーザーが同一だった(userId: `test-user-id`)
- 最初は問題ないがチューニングが進むと(マッチグループ作成と取得どちらもタイムアウトしないようになるくらい？)大量にマッチグループが作成されるため、取得すべきマッチグループも増える (初期状態の20からローカルだと1600まで増えていた)
- 取得処理中に新規でマッチグループが作成されると、齟齬が発生してエラー起きるかも (これは本当に起きるか分からない)
- 参加者が悪さをしない前提で、固定のユーザー`692ee607-9cdf-439b-8b06-1a435c99aa5a`に変更
  - test-user-idと同じく、初期データ上のマッチグループ参加数が16
  
```
  mysql> select count(*) from match_group_member where user_id = "692ee607-9cdf-439b-8b06-1a435c99aa5a";
+----------+
| count(*) |
+----------+
|       16 |
+----------+
1 row in set (0.00 sec)

mysql> select count(*) from match_group_member where user_id = "test-user-id";
+----------+
| count(*) |
+----------+
|       16 |
+----------+
1 row in set (0.00 sec)
```