### PR TITLE
fix: ユーザーアイコン画像取得APIにsleepを設定

### DIFF
--- a/benchmarker/src/loadTest.ts
+++ b/benchmarker/src/loadTest.ts
@@ -1,4 +1,4 @@
-import { check } from "k6";
+import { check, sleep } from "k6";
 import http from "k6/http";
 import { Options } from "k6/options";
 import exec from "k6/execution";
@@ -147,6 +147,7 @@ export const getUserIconAPI = () => {
   check(res, {
     "Get user icon: is status 200": () => res.status === 200,
   });
+  sleep(0.7);
 };
 
 export const getUsersAPI = () => {
@@ -199,7 +200,9 @@ export const createMatchGroupsAPI = () => {
 
 export const getMatchGroupsAPI = () => {
   const res = http.get(
-    url(`/api/v1/match-groups/members/692ee607-9cdf-439b-8b06-1a435c99aa5a?status=open`),
+    url(
+      `/api/v1/match-groups/members/692ee607-9cdf-439b-8b06-1a435c99aa5a?status=open`
+    ),
     {
       cookies: {
         SESSION_ID: "test-session-id",

--- a/run.sh
+++ b/run.sh
@@ -37,7 +37,7 @@ requestBody=`cat ./benchmarker/score/${fileName}.json | awk '{print substr($0, 2
 key=`cat ./.da/funcKey`
 repo=`cat /.da/cloneUrl`
 version="v2"
-statusCode=`curl -o /dev/null -w '%{http_code}\n' -s -X POST -d '{"hostname": "'$HOSTNAME'", "repo": "'$repo'","version": "'$version'", '$requestBody'}' "https://ftt2306.azurewebsites.net/api/HttpTrigger1?code=${key}"`curl -o /dev/null -w '%{http_code}\n' -s -X POST -d '{"hostname": "'$HOSTNAME'", "repo": "'$repo'", '$requestBody'}' "https://ftt2306.azurewebsites.net/api/HttpTrigger1?code=${key}"`
+statusCode=`curl -o /dev/null -w '%{http_code}\n' -s -X POST -d '{"hostname": "'$HOSTNAME'", "repo": "'$repo'","version": "'$version'", '$requestBody'}' "https://ftt2306.azurewebsites.net/api/HttpTrigger1?code=${key}"`
 
 if [ $statusCode = "200" ]; then
     echo "スコアの送信に成功しました。"

--- a/run.sh
+++ b/run.sh
@@ -36,7 +36,8 @@ echo "サーバーへスコアを送信します。"
 requestBody=`cat ./benchmarker/score/${fileName}.json | awk '{print substr($0, 2, length($0)-2)}'`
 key=`cat ./.da/funcKey`
 repo=`cat /.da/cloneUrl`
-statusCode=`curl -o /dev/null -w '%{http_code}\n' -s -X POST -d '{"hostname": "'$HOSTNAME'", "repo": "'$repo'", '$requestBody'}' "https://ftt2306.azurewebsites.net/api/HttpTrigger1?code=${key}"`
+version="v2"
+statusCode=`curl -o /dev/null -w '%{http_code}\n' -s -X POST -d '{"hostname": "'$HOSTNAME'", "repo": "'$repo'","version": "'$version'", '$requestBody'}' "https://ftt2306.azurewebsites.net/api/HttpTrigger1?code=${key}"`curl -o /dev/null -w '%{http_code}\n' -s -X POST -d '{"hostname": "'$HOSTNAME'", "repo": "'$repo'", '$requestBody'}' "https://ftt2306.azurewebsites.net/api/HttpTrigger1?code=${key}"`
 
 if [ $statusCode = "200" ]; then
     echo "スコアの送信に成功しました。"


### PR DESCRIPTION
### 概要
- ユーザーアイコン画像取得APIでnginxにキャッシュを効かせると、画像取得APIだけで10万回以上成功してしまっていた
- ユーザーアイコン画像取得APIには、レスポンスが返ってきてから次のリクエストを送るまでの間にsleep(0.7)を設定
- キャッシュを使っていても、分間6000回くらいに落ち着く予定
- 変更後のスコアを取得できるように、結果送信時に`"version": "v2"`を追記